### PR TITLE
Some reviewing

### DIFF
--- a/src/CatalogService/Model.cs
+++ b/src/CatalogService/Model.cs
@@ -65,7 +65,7 @@ public class CatalogDbContext(DbContextOptions<CatalogDbContext> options) : DbCo
             LIMIT {pageSize + 1}
         """;
 
-        return CatalogItems.FromSqlInterpolated(sql).ToListAsync();
+        return CatalogItems.FromSql(sql).ToListAsync();
     }
 
     public DbSet<CatalogItem> CatalogItems => Set<CatalogItem>();

--- a/src/CatalogService/Program.cs
+++ b/src/CatalogService/Program.cs
@@ -9,6 +9,7 @@ builder.Services.AddDbContextPool<CatalogDbContext>(options =>
         throw new InvalidDataException("Missing connection string CatalogDb");
 
     options.UseNpgsql(connectionString)
+           // Compiled model: this improves the startup time
            // https://learn.microsoft.com/ef/core/performance/advanced-performance-topics#compiled-models
            .UseModel(CatalogDbContextModel.Instance);
 


### PR DESCRIPTION
Hey,

Am abroad on vacation without too much time, so here's a dump of some comments rather than changes in the PR - but it should all be pretty straightforward. Ping me when done and I can do another pass on Monday/Tuesday.

(Awesome to see this perf-oriented EF demo!)

* Quick modeling note: for thin wrapper entities like CatalogType and CatalogBrand, it's sometimes better to just embed the wrapping string (Type/Brand) directly in the entities, rather than having a table with a one-to-many - this eliminates the need for joins etc. If there's an index on the field you can still very quickly find all items of a given type/brand etc.
* You're doing UseHiLo on the IDs of all entity types - this thing is only useful to reduce roundtrips when inserting both a principal and a dependent in the same roundtrip (e.g. Blog and Post, where Post references Blog and Blog has a db-generated int). I don't *think* that's the case here, and in fact HiLo can add additional roundtrips since EF has to pre-fetch a range of IDs to cache... So it may be a good idea to remove - unless you want to discuss this specifically.
* nit: no real need to specify IsRequired, EF automatically infers that from C# nullability (e.g. int/string are required by default, int?/string? are not)
* nit: in the model config you have multiple things like this: 

```c#
builder.HasOne(ci => ci.CatalogType)
    .WithMany()
    .HasForeignKey(ci => ci.CatalogTypeId);
```

* Rather than doing this explicit configuration, you can add a collection navigation property back from CatalogType to CatalogItem, and EF will automatically detect the navigation (and the foreign key). This reduces code and also makes it easier to e.g. query out all the items with a given catalog type.
* In general, there's some model config that isn't needed explicitly, like HasKey for Id (this is done implicitly by convention), ToTable("CatalogType") - you can reduce some code there.
* Instead of writing your own ToListAsync, IIRC you should be able to use System.Linq.Async, which is the standard thing that provides LINQ operators over IAsyncEnumerable. I really thing that belongs in .NET!
* Hurray for switch expressions and pattern matching: I've been having lots of fun with all that lately (e.g. [here](https://github.com/dotnet/efcore/blob/main/src/EFCore.Relational/Query/RelationalQueryableMethodTranslatingExpressionVisitor.cs#L1825)).
* In GetCatalogItemsSqlAsync, instead of using `NpgsqlParameter<int?>` in the FormattableString you should be able to embed the variables directly (simpler code).
* Awesome that you're using keyset pagination! FWIW ID usually isn't meaningful to users - usually you want to order by date/name or something similar (and it also leaks internal IDs) - but for a demo that's obviously fine.
* FWIW the dynamic operator composition in GetCatalogItemsAsync is the thing that won't be supported for NativeAOT if/when we ship that support (at least not at first) - in case you want to mention that. The workaround would be to just do the same thing you did in the compiled query.

/cc @ajcvickers