### PR TITLE
Form that, when posted, triggers an event that could add the item to the cart

### DIFF
--- a/src/Frontend/App.razor
+++ b/src/Frontend/App.razor
@@ -1,6 +1,11 @@
 ﻿@using Frontend.Components
+@using Microsoft.AspNetCore.Components.Forms
+@using System.Web;
+@page "/"
 @layout MainLayout
+@inject FormDataProvider FormData
 @inject CatalogService CatalogService
+@inject NavigationManager Nav
 @attribute [StreamRendering(true)]
 
 @if (catalog is { Data: var data })
@@ -19,10 +24,15 @@
                         <p class="item-description pointer-events-none">@item.Description</p>
                         <div class="d-flex justify-space-evenly align-items-center">
                             <p class="item-price pointer-events-none">@item.Price.ToString("C")</p>
-                            <button class="align-content-end cart-button" 
-                                title=@($"Add {@item.Name} to cart?")>
-                                <i class="fa fa-cart-plus" aria-hidden="true"></i>
-                            </button>
+                            <EditForm FormHandlerName="@(item.Id.ToString())"
+                                      Model="@ignored"
+                                      OnValidSubmit="@(() => AddToCart(item))"
+                                      method="post">
+                                <button type="submit" class="align-content-end cart-button" 
+                                    title=@($"Add {@item.Name} to cart?")>
+                                    <i class="fa fa-cart-plus" aria-hidden="true"></i>
+                                </button>
+                            </EditForm>
                         </div>
                     </div>
                 </div>
@@ -50,18 +60,20 @@ else
 }
 
 @code {
+    object ignored = new();
+    int? before;
+    int? after;
     Catalog? catalog;
     PaginationInfo paginationInfo = new(FirstId: 0, NextId: 0, HasPreviousPage: false, HasNextPage: false);
 
-    [Parameter]
-    public int? Before { get; set; }
-
-    [Parameter]
-    public int? After { get; set; }
-
     protected override async Task OnInitializedAsync()
     {
-        catalog = await CatalogService.GetItemsAsync(Before, After);
+        // Workaround for [SupplyParameterFromQuery] not being implemented for Razor Component endpoints yet
+        var query = HttpUtility.ParseQueryString(new Uri(Nav.Uri).Query);
+        before = int.TryParse(query.Get("before"), out var beforeParsed) ? beforeParsed : null;
+        after = int.TryParse(query.Get("after"), out var afterParsed) ? afterParsed : null;
+
+        catalog = await CatalogService.GetItemsAsync(before, after);
 
         if (catalog is null)
         {
@@ -71,5 +83,21 @@ else
         paginationInfo = new PaginationInfo(catalog.FirstId, catalog.NextId, catalog.FirstId > 1, !catalog.IsLastPage);
     }
 
+    void AddToCart(CatalogItem item)
+    {
+        // To actually add it to cart, we should add some Cart model either as a scoped DI service or
+        // as a cascading parameter, so it can be consumed by both <App> and <Cart>. It would have an
+        // "Add" method that triggers some event that other components can listen to and call their
+        // own "StateHasChanged". Alternatively, render the cart from <App> via the sections feature,
+        // so it can share the same info automatically.
+        Console.WriteLine("Trying to add to cart: " + item.Name);
+
+        // Note: we can't P/R/G yet because `DispatchCapturedEvent` doesn't catch and deal with NavigationException,
+        // so the following would just fail. It's also a bit painful having to remove the "handler" param manually.
+        // That problem could go away if "handler" was a hidden POST field.
+
+        // Nav.NavigateTo(Nav.GetUriWithQueryParameter("handler", (string?)null));
+    }
+    
     record PaginationInfo(int FirstId, int NextId, bool HasPreviousPage, bool HasNextPage);
 }

--- a/src/Frontend/Program.cs
+++ b/src/Frontend/Program.cs
@@ -20,8 +20,6 @@ app.UseStaticFiles();
 
 app.MapRazorComponents<MainLayout>();
 
-app.MapGet("/", (int? before, int? after) => new RazorComponentResult<App>(new { before, after }));
-
 app.MapForwarder("/catalog/images/{id}", catalogServiceUrl, "/api/v1/catalog/items/{id}/image");
 
 app.Run();


### PR DESCRIPTION
I've been trying out different approaches to do this using the new form post handling mechanisms. There were quite a few things that didn't seem to work, and I ran into a lot of unexpected errors (see below). Some of the issues are that things aren't yet fully implemented (below), some are that the design is sufficiently different from traditional form post handling that I got wrong expectations, and one seems to be a bug (below).

In the end, this PR does make it work, and the code isn't too strange. It's just hard to discover all this, and feels much harder than a traditional PHP-style "just have an OnPost handler that procedurally reads content from Request.Form". I also am not confident about how nicely I could generalize this to other scenarios that involve many-forms-one-handler, for example displaying validation status within the correct form instance out of the many.

### Bugs

Can't implement PRG currently because `DispatchCapturedEvent` doesn't catch and deal with `NavigationException`, so `NavigationManager.NavigateTo(...)` during form event dispatch fails.

### Not yet implemented

SupplyParameterFromQuery isn't implemented. This PR works around it by parsing the querystring explicitly.

SupplyParameterFromForm isn't implemented. I'm unsure how the patterns would change or improve if this was implemented.

PRG wouldn't work end-to-end in conjunction with streaming rendering because we don't yet have the JS part of this (we don't yet do the client-side redirection when the server sends the redirection instruction).

### Unexpected errors / Development experience

Initially I tried `<form method="post" @onsubmit="@AddToCart">` containing a hidden input for the item ID.

 * At first I was getting 405 errors. Realised this was because it's using minimal API and `RazorComponentResult`. Fixed by changing it to `MapRazorComponents`.
 * Then I was getting `InvalidOperationException: No named event handler was captured for ''.` That's extremely hard to understand - it doesn't provide any clues on how to fix it. I realised I needed to add some kind of handler ID or name but it's unclear how to discover how to do that.
 * After reading the code for EditForm I wrapped the form in a `<CascadingModelBinder Name="@item.Id">` and added to the form both `name=@context.Name` and `action=@context.BindingContextId`, though I don't know why I need to specify both - seems redundant.
 * Now the error is `InvalidOperationException: No named event handler was captured for '3'.`
 * After reading more of the code I realised that it won't work with `<form>` because it relies on something calling `builder.SetEventHandlerName`.
 * Switched to `<EditForm method="post" OnValidSubmit="AddToCart">` - failed with `System.InvalidOperationException: EditForm requires either a Model parameter, or an EditContext parameter, please provide one of these.`
 * Added `Model="@(new object())"` because I don't think I really need a model. Now on submit it fails with `InvalidOperationException: No named event handler was captured for ''.`
 * Realised I need to set `FormHandlerName="@item.Id.ToString()"`. The `ToString` is irksome but I get it. Now on submit the error is `InvalidOperationException: The named event '3' was already defined earlier by a component with id '24' but this component was removed before receiving the dispatched event.` This is pretty hard to understand.
 * Eventually I found this is because of `Model="@(new object())"` producing a different instance on each render, though TBH I still don't know why it leads to the specific error it does. Fixed it by adding a field `object ignored = new();` and setting `Model="@ignored"` on the form. Now it works! Or at least, `AddToCart` runs and I can hit a breakpoint in it.
 * But how do I pass the item ID into this handler?
   * First I tried to add a parameter, so it becomes `void AddToCart(AddToCartModel model)` where `AddToCartModel` is a record matching the shape of the form post. Nope, that's not a valid event handler method signature.
   * Second I went through the flow in https://devblogs.microsoft.com/dotnet/asp-net-core-updates-in-dotnet-8-preview-4/#blazor where I `@inject FormDataProvider FormData` and then manually parse the hidden input. This works.
   * Then I realised I could use a lambda: `OnValidSubmit="@(() => AddToCart(item))"` so it no longer has to have a hidden input or parse anything. This is great but wouldn't work if I was also trying to receive other form data like text from an `<input>`.
   * Then I tried to implement P/R/G by doing `NavigationManager.NavigateTo`. It was hard to figure out how to remove the `handler` querystring parameter, and feels risky because if the framework renames that in the future my code would be broken. But I found that `Nav.GetUriWithQueryParameter("handler", (string?)null)` does work, albeit being annoying (we should at least have `GetUriWithoutQueryParameter`). Still fails at runtime due to the bug mentioned above.